### PR TITLE
Add travis.yml and "run_for_all" to execute builds or tests for all crates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: rust
+script:
+  - ./run_for_all build --verbose
+  - ./run_for_all test --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: rust
 script:
-  - ./run_for_all build --verbose
-  - ./run_for_all test --verbose
+  - ./run_for_all.sh build --verbose
+  - ./run_for_all.sh test --verbose

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Stockpile
+[![Build Status](https://travis-ci.org/acmcarther/stockpile.svg)](https://travis-ci.org/acmcarther/stockpile)
 
 An alternative resolution strategy for Cargo crates.
 

--- a/run_for_all.sh
+++ b/run_for_all.sh
@@ -1,0 +1,17 @@
+#! /usr/bin/env bash
+
+function run_all {
+  for TOML_DIR in $(find . -type f | grep "Cargo.toml$" | sed "s/Cargo.toml$//g")
+  do
+    (cd $TOML_DIR && (cargo $@)) || return 1
+  done
+  return 0
+}
+
+if [[ ! "$PWD" =~ "stockpile" ]]; then
+  echo "Please run $0 from the stockpile directory"
+  exit 1
+fi
+
+run_all $@
+


### PR DESCRIPTION
This PR adds a basic script that finds tomls, then runs a cargo command for all of them. This has terrible caching behavior, but it works for now.

With that, we can now test with Travis, so I've added that as well.