### PR TITLE
Make UpstreamIndex generic for use as AugmentedIndex

### DIFF
--- a/jobs/src/index.rs
+++ b/jobs/src/index.rs
@@ -72,14 +72,12 @@ define_from_error_boilerplate!(git2::Error, GenericIndexErr, GenericIndexErr::Gi
 define_from_error_boilerplate!(io::Error, GenericIndexErr, GenericIndexErr::IoErr);
 define_from_error_boilerplate!(serde_json::Error, GenericIndexErr, GenericIndexErr::SerdeJsonErr);
 
-impl Default for GenericIndex<cargo::IndexEntry> {
-  /** Builds an GenericIndex from flags. */
-  fn default() -> GenericIndex<cargo::IndexEntry> {
+impl GenericIndex<cargo::IndexEntry> {
+  /** Builds a Crates.io GenericIndex from flags. */
+  pub fn crates_io_index() -> GenericIndex<cargo::IndexEntry> {
     GenericIndex::load_from_params(GenericIndexParams::crates_io_index_params()).unwrap()
   }
-}
 
-impl GenericIndex<cargo::IndexEntry> {
   /** Retrieves all known CrateKey objects from the index. */
   pub fn get_all_crate_keys(&self) -> Vec<CrateKey> {
     self.in_memory_index.values()

--- a/jobs/src/index.rs
+++ b/jobs/src/index.rs
@@ -19,12 +19,12 @@ use tempdir::TempDir;
 use url::Url;
 
 mod flags {
-  define_pub_cfg!(in_memory_index_url,
+  define_pub_cfg!(crates_io_index_url,
                   String,
                   "https://github.com/rust-lang/crates.io-index",
                   "The URL for the upstream crates.io index repository");
 
-  define_pub_cfg!(pre_pulled_in_memory_index_directory,
+  define_pub_cfg!(pre_pulled_crates_io_index_directory,
                   ::zcfg::NoneableCfg<String>,
                   None,
                   "The path to the crates.io index to use in lieu of pulling a fresh copy.");
@@ -32,17 +32,16 @@ mod flags {
 
 /** Defines the params needed to build an GenericIndex. */
 #[derive(Builder)]
-#[builder(default)]
 pub struct GenericIndexParams {
   url: Url,
   pre_pulled_index_path: Option<PathBuf>,
 }
 
-impl Default for GenericIndexParams {
+impl GenericIndexParams {
   /** Constructs an GenericIndexParams from flags. */
-  fn default() -> GenericIndexParams {
-    let url = Url::parse(&flags::in_memory_index_url::CONFIG.get_value()).unwrap();
-    let pre_pulled_index_path = flags::pre_pulled_in_memory_index_directory::CONFIG.get_value().inner()
+  fn crates_io_index_params() -> GenericIndexParams {
+    let url = Url::parse(&flags::crates_io_index_url::CONFIG.get_value()).unwrap();
+    let pre_pulled_index_path = flags::pre_pulled_crates_io_index_directory::CONFIG.get_value().inner()
       .map(PathBuf::from);
 
     GenericIndexParams {
@@ -73,10 +72,10 @@ define_from_error_boilerplate!(git2::Error, GenericIndexErr, GenericIndexErr::Gi
 define_from_error_boilerplate!(io::Error, GenericIndexErr, GenericIndexErr::IoErr);
 define_from_error_boilerplate!(serde_json::Error, GenericIndexErr, GenericIndexErr::SerdeJsonErr);
 
-impl <T: Serialize + DeserializeOwned + Send> Default for GenericIndex<T> {
+impl Default for GenericIndex<cargo::IndexEntry> {
   /** Builds an GenericIndex from flags. */
-  fn default() -> GenericIndex<T> {
-    GenericIndex::load_from_params(GenericIndexParams::default()).unwrap()
+  fn default() -> GenericIndex<cargo::IndexEntry> {
+    GenericIndex::load_from_params(GenericIndexParams::crates_io_index_params()).unwrap()
   }
 }
 

--- a/jobs/src/lcs_fetcher/mod.rs
+++ b/jobs/src/lcs_fetcher/mod.rs
@@ -1,6 +1,6 @@
 use tempdir::TempDir;
 use common::cargo;
-use index::UpstreamIndex;
+use index::GenericIndex;
 use super::Job;
 use std::fs;
 use std::path::PathBuf;
@@ -31,7 +31,7 @@ mod repository;
  */
 #[derive(Builder)]
 pub struct LcsFetcherJob {
-  upstream_index: UpstreamIndex<cargo::IndexEntry>,
+  upstream_index: GenericIndex<cargo::IndexEntry>,
   lcs_source: Box<LcsRepositorySource>,
   lcs_sink: Box<LcsRepositorySink>,
   #[builder(default)]
@@ -65,7 +65,7 @@ define_from_error_boilerplate!(S3Error, LcsFetchErr, LcsFetchErr::S3Err);
 impl LcsFetcherJob {
   pub fn from_crates_io_to_s3() -> LcsFetcherJob {
     LcsFetcherJobBuilder::default()
-      .upstream_index(UpstreamIndex::default())
+      .upstream_index(GenericIndex::default())
       .lcs_source(Box::new(HttpLcsRepository::default()))
       .lcs_sink(Box::new(S3LcsRepository::default()))
       .build()
@@ -74,7 +74,7 @@ impl LcsFetcherJob {
 
   pub fn from_crates_io_to_cwd() -> LcsFetcherJob {
     LcsFetcherJobBuilder::default()
-      .upstream_index(UpstreamIndex::default())
+      .upstream_index(GenericIndex::default())
       .lcs_source(Box::new(HttpLcsRepository::default()))
       .lcs_sink(Box::new(LocalFsLcsRepository::from_cwd().unwrap()))
       .build()
@@ -133,8 +133,8 @@ impl Job for LcsFetcherJob {
 
 #[cfg(test)]
 mod tests {
-  use index::UpstreamIndex;
-  use index::UpstreamIndexParamsBuilder;
+  use index::GenericIndex;
+  use index::GenericIndexParamsBuilder;
   use index;
   use lcs_fetcher::LcsFetcherJobBuilder;
   use lcs_fetcher::repository::LocalFsLcsRepository;
@@ -145,12 +145,12 @@ mod tests {
     let dest_fs_lcs = LocalFsLcsRepository::from_tmp().unwrap();
     let upstream_index = {
       let tempdir = index::testing::seed_minimum_index();
-      let params = UpstreamIndexParamsBuilder::default()
+      let params = GenericIndexParamsBuilder::default()
         .pre_pulled_index_path(Some(tempdir.path().to_path_buf()))
         .build()
         .unwrap();
 
-      UpstreamIndex::load_from_params(params).unwrap()
+      GenericIndex::load_from_params(params).unwrap()
     };
 
     let mut lcs_fetcher_job =

--- a/jobs/src/lcs_fetcher/mod.rs
+++ b/jobs/src/lcs_fetcher/mod.rs
@@ -65,7 +65,7 @@ define_from_error_boilerplate!(S3Error, LcsFetchErr, LcsFetchErr::S3Err);
 impl LcsFetcherJob {
   pub fn from_crates_io_to_s3() -> LcsFetcherJob {
     LcsFetcherJobBuilder::default()
-      .upstream_index(GenericIndex::default())
+      .upstream_index(GenericIndex::crates_io_index())
       .lcs_source(Box::new(HttpLcsRepository::default()))
       .lcs_sink(Box::new(S3LcsRepository::default()))
       .build()
@@ -74,7 +74,7 @@ impl LcsFetcherJob {
 
   pub fn from_crates_io_to_cwd() -> LcsFetcherJob {
     LcsFetcherJobBuilder::default()
-      .upstream_index(GenericIndex::default())
+      .upstream_index(GenericIndex::crates_io_index())
       .lcs_source(Box::new(HttpLcsRepository::default()))
       .lcs_sink(Box::new(LocalFsLcsRepository::from_cwd().unwrap()))
       .build()

--- a/jobs/src/lcs_fetcher/mod.rs
+++ b/jobs/src/lcs_fetcher/mod.rs
@@ -1,4 +1,5 @@
 use tempdir::TempDir;
+use common::cargo;
 use index::UpstreamIndex;
 use super::Job;
 use std::fs;
@@ -30,7 +31,7 @@ mod repository;
  */
 #[derive(Builder)]
 pub struct LcsFetcherJob {
-  upstream_index: UpstreamIndex,
+  upstream_index: UpstreamIndex<cargo::IndexEntry>,
   lcs_source: Box<LcsRepositorySource>,
   lcs_sink: Box<LcsRepositorySink>,
   #[builder(default)]

--- a/jobs/src/lcs_fetcher/mod.rs
+++ b/jobs/src/lcs_fetcher/mod.rs
@@ -136,6 +136,8 @@ mod tests {
   use index::GenericIndex;
   use index::GenericIndexParamsBuilder;
   use index;
+  use url::Url;
+  use std::str::FromStr;
   use lcs_fetcher::LcsFetcherJobBuilder;
   use lcs_fetcher::repository::LocalFsLcsRepository;
 
@@ -146,6 +148,7 @@ mod tests {
     let upstream_index = {
       let tempdir = index::testing::seed_minimum_index();
       let params = GenericIndexParamsBuilder::default()
+        .url(Url::from_str("http://invalid-url").unwrap())
         .pre_pulled_index_path(Some(tempdir.path().to_path_buf()))
         .build()
         .unwrap();


### PR DESCRIPTION
This PR moves "cargo::IndexEntry" into a type parameter of what was formerly UpstreamIndex, so that it may be reused for the AugmentedIndex object.

The AugmentedIndex has the same folder structure and general properties as UpstreamIndex, but different contents.